### PR TITLE
Replace netstandard with netcoreapp

### DIFF
--- a/provide/provide.csproj
+++ b/provide/provide.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackageId>Provide</PackageId>
     <Version>2.0.3</Version>
     <Authors>Kyle Thomas</Authors>


### PR DESCRIPTION
This looks like only change needed, run `dotnet build` and `make test` to confirm it's working. Also it seems that netstandard is obsolete and should be replaced with netcoreapp anyways.