### PR TITLE
Fix nats url

### DIFF
--- a/provide/Services/NatsClient.cs
+++ b/provide/Services/NatsClient.cs
@@ -26,7 +26,7 @@ namespace provide
             this.path = path;
             this.scheme = scheme;
             this.token = token;
-            this.natsUrl = $"{scheme}://${host}/${path}/";
+            this.natsUrl = $"{scheme}://{host}/{path}";
         }
 
         public void Connect()


### PR DESCRIPTION
Tested connecting to nats://demo.nats.io:4222.
Connection works also without port specified, client will default to 4222.
It also works without scheme specified (demo.nats.io), should we add support for this in constructor, or not needed atm?